### PR TITLE
Fix attributes coping executable and refactor tab completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+This project has been archived. Raspberry's decision to effectively abandon hobbyists and
+makers in order to satisfy commercial demand motivated this action.
+
 A tiny Raspberry Pico shell with flash file system, Vi, and C compiler.
 
 This project explores to what extent a reasonably competent self-hosted programming environment can be built on a modern embedded SoC.

--- a/src/main.c
+++ b/src/main.c
@@ -287,8 +287,8 @@ static void cp_cmd(void) {
     if (out_ok)
         fs_file_close(&out);
     if (buf) {
-        if (out_ok && fs_getattr(from, 1, buf, 3) == 3 && memcmp(buf, "exe", 3) == 0)
-            fs_setattr(to, 1, buf, 3);
+        if (out_ok && fs_getattr(from, 1, buf, 4) == 4 && memcmp(buf, "exe", 4) == 0)
+            fs_setattr(to, 1, buf, 4);
         free(buf);
     }
     if (!result[0])


### PR DESCRIPTION
Attributes for executable files weren't copied correctly in main.c and is now fixed.

Tab completion in dgreadln.c has been refactored to alow files in /bin and the current directory to be treated commands.